### PR TITLE
Use the correct package name for composable kinds

### DIFF
--- a/grafana/next/composable/alertgroups/panelcfg.cue
+++ b/grafana/next/composable/alertgroups/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/annotationslist/panelcfg.cue
+++ b/grafana/next/composable/annotationslist/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/azuremonitor/dataquery.cue
+++ b/grafana/next/composable/azuremonitor/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/barchart/panelcfg.cue
+++ b/grafana/next/composable/barchart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/bargauge/panelcfg.cue
+++ b/grafana/next/composable/bargauge/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/candlestick/panelcfg.cue
+++ b/grafana/next/composable/candlestick/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/canvas/panelcfg.cue
+++ b/grafana/next/composable/canvas/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/cloudwatch/dataquery.cue
+++ b/grafana/next/composable/cloudwatch/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/dashboardlist/panelcfg.cue
+++ b/grafana/next/composable/dashboardlist/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/datagrid/panelcfg.cue
+++ b/grafana/next/composable/datagrid/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/debug/panelcfg.cue
+++ b/grafana/next/composable/debug/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/elasticsearch/dataquery.cue
+++ b/grafana/next/composable/elasticsearch/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/gauge/panelcfg.cue
+++ b/grafana/next/composable/gauge/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/geomap/panelcfg.cue
+++ b/grafana/next/composable/geomap/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/googlecloudmonitoring/dataquery.cue
+++ b/grafana/next/composable/googlecloudmonitoring/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/grafanapyroscope/dataquery.cue
+++ b/grafana/next/composable/grafanapyroscope/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/heatmap/panelcfg.cue
+++ b/grafana/next/composable/heatmap/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/histogram/panelcfg.cue
+++ b/grafana/next/composable/histogram/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/logs/panelcfg.cue
+++ b/grafana/next/composable/logs/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/loki/dataquery.cue
+++ b/grafana/next/composable/loki/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/news/panelcfg.cue
+++ b/grafana/next/composable/news/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/nodegraph/panelcfg.cue
+++ b/grafana/next/composable/nodegraph/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/parca/dataquery.cue
+++ b/grafana/next/composable/parca/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/piechart/panelcfg.cue
+++ b/grafana/next/composable/piechart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/prometheus/dataquery.cue
+++ b/grafana/next/composable/prometheus/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/stat/panelcfg.cue
+++ b/grafana/next/composable/stat/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/statetimeline/panelcfg.cue
+++ b/grafana/next/composable/statetimeline/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/statushistory/panelcfg.cue
+++ b/grafana/next/composable/statushistory/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/table/panelcfg.cue
+++ b/grafana/next/composable/table/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/tempo/dataquery.cue
+++ b/grafana/next/composable/tempo/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/testdata/dataquery.cue
+++ b/grafana/next/composable/testdata/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/text/panelcfg.cue
+++ b/grafana/next/composable/text/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/next/composable/timeseries/panelcfg.cue
+++ b/grafana/next/composable/timeseries/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/trend/panelcfg.cue
+++ b/grafana/next/composable/trend/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/next/composable/xychart/panelcfg.cue
+++ b/grafana/next/composable/xychart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/alertgroups/panelcfg.cue
+++ b/grafana/v10.1.0/composable/alertgroups/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/annotationslist/panelcfg.cue
+++ b/grafana/v10.1.0/composable/annotationslist/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/azuremonitor/dataquery.cue
+++ b/grafana/v10.1.0/composable/azuremonitor/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/barchart/panelcfg.cue
+++ b/grafana/v10.1.0/composable/barchart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/bargauge/panelcfg.cue
+++ b/grafana/v10.1.0/composable/bargauge/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/candlestick/panelcfg.cue
+++ b/grafana/v10.1.0/composable/candlestick/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/canvas/panelcfg.cue
+++ b/grafana/v10.1.0/composable/canvas/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/cloudwatch/dataquery.cue
+++ b/grafana/v10.1.0/composable/cloudwatch/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/dashboardlist/panelcfg.cue
+++ b/grafana/v10.1.0/composable/dashboardlist/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/datagrid/panelcfg.cue
+++ b/grafana/v10.1.0/composable/datagrid/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/debug/panelcfg.cue
+++ b/grafana/v10.1.0/composable/debug/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/elasticsearch/dataquery.cue
+++ b/grafana/v10.1.0/composable/elasticsearch/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/gauge/panelcfg.cue
+++ b/grafana/v10.1.0/composable/gauge/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/geomap/panelcfg.cue
+++ b/grafana/v10.1.0/composable/geomap/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/googlecloudmonitoring/dataquery.cue
+++ b/grafana/v10.1.0/composable/googlecloudmonitoring/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/grafanapyroscope/dataquery.cue
+++ b/grafana/v10.1.0/composable/grafanapyroscope/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/heatmap/panelcfg.cue
+++ b/grafana/v10.1.0/composable/heatmap/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/histogram/panelcfg.cue
+++ b/grafana/v10.1.0/composable/histogram/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/logs/panelcfg.cue
+++ b/grafana/v10.1.0/composable/logs/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/loki/dataquery.cue
+++ b/grafana/v10.1.0/composable/loki/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/news/panelcfg.cue
+++ b/grafana/v10.1.0/composable/news/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/nodegraph/panelcfg.cue
+++ b/grafana/v10.1.0/composable/nodegraph/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/parca/dataquery.cue
+++ b/grafana/v10.1.0/composable/parca/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/piechart/panelcfg.cue
+++ b/grafana/v10.1.0/composable/piechart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/prometheus/dataquery.cue
+++ b/grafana/v10.1.0/composable/prometheus/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/stat/panelcfg.cue
+++ b/grafana/v10.1.0/composable/stat/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/statetimeline/panelcfg.cue
+++ b/grafana/v10.1.0/composable/statetimeline/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/statushistory/panelcfg.cue
+++ b/grafana/v10.1.0/composable/statushistory/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/table/panelcfg.cue
+++ b/grafana/v10.1.0/composable/table/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/tempo/dataquery.cue
+++ b/grafana/v10.1.0/composable/tempo/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/testdata/dataquery.cue
+++ b/grafana/v10.1.0/composable/testdata/dataquery.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/text/panelcfg.cue
+++ b/grafana/v10.1.0/composable/text/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import "github.com/grafana/kindsys"
 

--- a/grafana/v10.1.0/composable/timeseries/panelcfg.cue
+++ b/grafana/v10.1.0/composable/timeseries/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/trend/panelcfg.cue
+++ b/grafana/v10.1.0/composable/trend/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"

--- a/grafana/v10.1.0/composable/xychart/panelcfg.cue
+++ b/grafana/v10.1.0/composable/xychart/panelcfg.cue
@@ -1,4 +1,4 @@
-package kind
+package grafanaplugin
 
 import (
 	"github.com/grafana/kindsys"


### PR DESCRIPTION
The expected package name for composable kinds was incorrectly set, preventing us from loading them correctly afterwards.